### PR TITLE
Change permission check to edit_document

### DIFF
--- a/core/components/quickbar/elements/snippets/snippet.quickbar.php
+++ b/core/components/quickbar/elements/snippets/snippet.quickbar.php
@@ -1,5 +1,5 @@
 <?php
-if (!$modx->user->hasSessionContext('mgr') || !$modx->hasPermission('edit_resource') ) return '';
+if (!$modx->user->hasSessionContext('mgr') || !$modx->hasPermission('edit_document') ) return '';
 
 $defaultQuickBarCorePath = $modx->getOption('core_path').'components/quickbar/';
 $quickbarsCorePath = $modx->getOption('quickbar.core_path',null,$defaultQuickBarCorePath);


### PR DESCRIPTION
Change hasPermission call to check for "edit_document" rather than "edit_resource" so that QuickBar will work properly for non-Administrator users.
